### PR TITLE
Installation now performs strip on binaries in release mode

### DIFF
--- a/dist/config.lua.in
+++ b/dist/config.lua.in
@@ -89,7 +89,15 @@ ctest         = "ctest"
 
 cache_command = cmake .. " -C cache.cmake"
 build_command = cmake .. " --build . --clean-first"
-install_component_command = cmake .. " -DCOMPONENT=#COMPONENT# -P cmake_install.cmake"
+
+if debug then
+	strip_option = ""
+else
+	strip_option = " -DCMAKE_INSTALL_DO_STRIP=true"
+end
+
+install_component_command = cmake .. strip_option .. " -DCOMPONENT=#COMPONENT# -P cmake_install.cmake"
+
 test_command = ctest .. " -V ."
 
 cache_debug_options = "-DCMAKE_VERBOSE_MAKEFILE=true -DCMAKE_BUILD_TYPE=Debug"


### PR DESCRIPTION
This change will ensure that all binaries are stripped before installation when installing in release mode (debug=false). This is essential for binary releases and all binary modules uploaded before this change should be updated.
