### PR TITLE
enable boostrapping with Lua5.2

### DIFF
--- a/dist/manifest.lua
+++ b/dist/manifest.lua
@@ -97,11 +97,9 @@ function load_manifest(manifest_file)
 
     if sys.exists(manifest_file) then
         -- load the manifest file
-        local manifest, err = loadfile(manifest_file)
+        local manifest_env = {}
+        local manifest, err = loadfile(manifest_file, 'bt', manifest_env)
         if not manifest then return nil, "Error when loading manifest file '" .. manifest_file .. "':" .. err end
-
-        -- set clear environment for the manifest file execution
-        setfenv(manifest, {})
 
         return manifest()
     else
@@ -191,12 +189,9 @@ function load_distinfo(distinfo_file)
     end
 
     -- load the distinfo file
-    local distinfo, err = loadfile(distinfo_file)
-    if not distinfo then return nil, "Error when loading package info:" .. err end
-
-    -- set clear environment for the distinfo file execution and collect values into it
     local distinfo_env = {}
-    setfenv(distinfo, distinfo_env)
+    local distinfo, err = loadfile(distinfo_file, 'bt', distinfo_env)
+    if not distinfo then return nil, "Error when loading package info:" .. err end
     distinfo()
 
     return distinfo_env

--- a/dist/sys.lua
+++ b/dist/sys.lua
@@ -85,7 +85,7 @@ function exec(command, force_verbose)
     if cfg.debug then print("Executing the command: " .. command) end
     local ok = os.execute(command)
 
-    if ok ~= 0 then
+    if ok == nil then
         return nil, "Error when running the command: " .. command
     else
         return true, "Sucessfully executed the command: " .. command
@@ -205,7 +205,7 @@ end
 -- Compose path composed from specified parts or current
 -- working directory when no part specified.
 function make_path(...)
-    local parts = arg
+    local parts = table.pack(...)
     assert(type(parts) == "table", "sys.make_path: Argument 'parts' is not a table.")
 
     local path, err


### PR DESCRIPTION
Hi,

Here is a first step to make LuaDist running with Lua5.2.

This commit enables to boostrap LuaDist with Lua5.2.
For now it works if you checkout the "master" branch for each boostrap.git submodules, except for luasocket where you need to checkout the "unstable" branch.

It is worth noting the second boostrap phase (i.e. LuaDist building with itself) actually builds LuaDist with dependency versions than may differ from the dependency versions used to fill the _boostrap directory (due to the install getting dependency sources by itself).
Consequently _install binaries files versions may differ from _boostrap binaries files versions.

Do you plan to upgrade to 5.2 into master or to create a separated Lua5.2 branch ?

Thanks in advance for your answer,

  Cyril Romain
