### PR TITLE
Lua 5.2 boostrapping compatibility

### DIFF
--- a/dist/sys.lua
+++ b/dist/sys.lua
@@ -83,9 +83,12 @@ function exec(command, force_verbose)
     end
 
     if cfg.debug then print("Executing the command: " .. command) end
-    local ok = os.execute(command)
+    local ok, str, status  = os.execute(command)
 
-    if ok ~= 0 then
+    -- os.execute returned values on failure are:
+    --  nil or true, "exit", n or true, "signal", n for lua >= 5.2
+    --  status ~= 0 for lua 5.x < 5.2
+    if ok == nil or (str == "exit" and status ~= 0) or str == "signal" or (ok ~= 0 and ok ~= true) then
         return nil, "Error when running the command: " .. command
     else
         return true, "Sucessfully executed the command: " .. command
@@ -205,6 +208,8 @@ end
 -- Compose path composed from specified parts or current
 -- working directory when no part specified.
 function make_path(...)
+    -- arg is deprecated in lua 5.2 in favor of table.pack we mimic here
+    local arg = {n=select('#',...),...}
     local parts = arg
     assert(type(parts) == "table", "sys.make_path: Argument 'parts' is not a table.")
 


### PR DESCRIPTION
Hey,

I just rewrote my changes to enable boostrapping with Lua 5.2 but keeping the code compatible with lua 5.1, so that luadist-git can be installed with both versions.

So no need for a lua-5.2 branch ;-)

Best regards,

  Cyril

PS : as noted previously :
- one need to checkout the luasocket "unstable" branch to compile luasocket with Lua 5.2.
- LuaDist is built with Lua5.2, i.e. the _boostrap creation is OK and includes Lua5.2, but for a reason I ignore when LuaDist builds with LuaDist it actually (re)checkouts and builds Lua5.1.5 and fills the _install directory with that version instead of Lua5.2. Any idea why ?
