### PR TITLE
move => rmdir (supported from win95)

### DIFF
--- a/dist/sys.lua
+++ b/dist/sys.lua
@@ -376,8 +376,11 @@ function delete(path)
         elseif is_file(path) then
             return os.remove(path)
         else
-            --return exec("rd /S /Q " .. quote(path))
-            return exec("move /y " .. quote(path) .. " " .. quote(tmp_dir()))
+            -- return exec("rd /S /Q " .. quote(path))
+            -- return exec("move /y " .. quote(path) .. " " .. quote(tmp_dir()))
+			
+			-- rmdir is suported from win95
+			return exec("rmdir /s /q " .. quote(path))
         end
     else
         return exec("rm -rf " .. quote(path))


### PR DESCRIPTION
on win10   move (dos command) will fail with access denied if destination directory exists
so for dir remove is better to use rmdir instead of move dir to tmp
